### PR TITLE
[Installation] Clarify pacman/Arch Linux instructions

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -77,9 +77,9 @@ To update, run:
 brew upgrade yt-dlp
 ```
 
-### [AUR](https://aur.archlinux.org/packages/yt-dlp-git)
+### [pacman](https://archlinux.org/packages/community/any/yt-dlp/)
 
-Arch Linux users can install it from the AUR:
+Arch Linux users can install it from the official community repository:
 ```bash
 pacman -Sy yt-dlp
 ```

--- a/Installation.md
+++ b/Installation.md
@@ -81,12 +81,12 @@ brew upgrade yt-dlp
 
 Arch Linux users can install it from the official community repository:
 ```bash
-pacman -Sy yt-dlp
+pacman -Syu yt-dlp
 ```
 
-To update, run:
+pacman will now automatically download the correct dependencies and keep the package up-to-date whenever you update your system with:
 ```bash
-pacman -Syu yt-dlp
+pacman -Syu
 ```
 
 ### [APT](https://en.wikipedia.org/wiki/APT_(software))


### PR DESCRIPTION
yt-dlp was moved to the arch official community repository months ago, and it is usually more up-to-date than the unofficial AUR git package.

Partial upgrades are unsupported by Arch Linux (the Arch wiki specifically advises against `pacman -Sy <package>`); the pacman command lines have been edited to reflect best practice