### PR TITLE
Add link for Debian yt-dlp repository.

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -114,6 +114,7 @@ Your system's package manager will now automatically download the correct depend
 sudo apt update
 sudo apt install yt-dlp
 ```
+The [Debian package](https://salsa.debian.org/debian/yt-dlp) is upstream for the Ubuntu ppa.
 
 ### [MacPorts](https://ports.macports.org/port/yt-dlp/)
 


### PR DESCRIPTION
The Ubuntu PPA depends on the Debian upstream (the link for which is buried several links down on Launchpad).  Packaging delays need to be addressed via Debian so include it here.