### PR TITLE
Recommend .local/bin instead of /usr/local/bin

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -11,7 +11,7 @@ You can simply download the [correct binary file](https://github.com/yt-dlp/yt-d
 [![MacOS](https://img.shields.io/badge/-MacOS-lightblue.svg?style=for-the-badge&logo=apple)](https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos)
 [![Other variants](https://img.shields.io/badge/-Other-grey.svg?style=for-the-badge)](https://github.com/yt-dlp/yt-dlp#release-files)
 
-In UNIX-like OSes (MacOS, Linux, BSD), you can also install the application into a location in your path.  For example, you can install into `~/.local/bin` in one of the following ways:
+In UNIX-like OSes (MacOS, Linux, BSD), you can also install the application into a location in your `$PATH`, such as `~/.local/bin`, in one of the following ways:
 
 ```bash
 curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o ~/.local/bin/yt-dlp

--- a/Installation.md
+++ b/Installation.md
@@ -11,7 +11,7 @@ You can simply download the [correct binary file](https://github.com/yt-dlp/yt-d
 [![MacOS](https://img.shields.io/badge/-MacOS-lightblue.svg?style=for-the-badge&logo=apple)](https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos)
 [![Other variants](https://img.shields.io/badge/-Other-grey.svg?style=for-the-badge)](https://github.com/yt-dlp/yt-dlp#release-files)
 
-In UNIX-like OSes (MacOS, Linux, BSD), you can also install the same in one of the following ways:
+In UNIX-like OSes (MacOS, Linux, BSD), you can also install the application into a location in your path.  For example, you can install into `~/.local/bin` in one of the following ways:
 
 ```bash
 curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o ~/.local/bin/yt-dlp

--- a/Installation.md
+++ b/Installation.md
@@ -14,42 +14,24 @@ You can simply download the [correct binary file](https://github.com/yt-dlp/yt-d
 In UNIX-like OSes (MacOS, Linux, BSD), you can also install the same in one of the following ways:
 
 ```bash
-mkdir -p ~/bin
-curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o ~/bin/yt-dlp
-chmod a+rx ~/bin/yt-dlp  # Make executable
+curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o ~/.local/bin/yt-dlp
+chmod a+rx ~/.local/bin/yt-dlp  # Make executable
 ```
 
 ```bash
-mkdir -p ~/bin
-wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O ~/bin/yt-dlp
-chmod a+rx ~/bin/yt-dlp  # Make executable
+wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O ~/.local/bin/yt-dlp
+chmod a+rx ~/.local/bin/yt-dlp  # Make executable
 ```
 
 ```bash
-mkdir -p ~/bin
-aria2c https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp --dir ~/bin -o yt-dlp
-chmod a+rx ~/bin/yt-dlp  # Make executable
-```
-
-If `~/bin` is not already in your path, you can add it
-###### Linux,BSD
-Edit your the appropriate file for your shell(i.e. `~/.bashrc`, `~/.zshrc`, etc) and add the following:
-```bash
-PATH=$PATH:~/bin
-export PATH
-```
-
-###### MacOS
-Create a file `/etc/path.d/80_bin` with the following contents
-```text
-~/bin
+aria2c https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp --dir ~/.local/bin -o yt-dlp
+chmod a+rx ~/.local/bin/yt-dlp  # Make executable
 ```
 
 To update, run: 
 ```bash
 yt-dlp -U
 ```
-
 
 
 # With [PIP](https://pypi.org/project/pip)

--- a/Installation.md
+++ b/Installation.md
@@ -14,25 +14,24 @@ You can simply download the [correct binary file](https://github.com/yt-dlp/yt-d
 In UNIX-like OSes (MacOS, Linux, BSD), you can also install the same in one of the following ways:
 
 ```bash
-sudo curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/yt-dlp
-sudo chmod a+rx /usr/local/bin/yt-dlp  # Make executable
+curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o ~/.local/bin/yt-dlp
+chmod a+rx ~/.local/bin/yt-dlp  # Make executable
 ```
 
 ```bash
-sudo wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O /usr/local/bin/yt-dlp
-sudo chmod a+rx /usr/local/bin/yt-dlp  # Make executable
+wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O ~/.local/bin/yt-dlp
+chmod a+rx ~/.local/bin/yt-dlp  # Make executable
 ```
 
 ```bash
-sudo aria2c https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp --dir /usr/local/bin -o yt-dlp
-sudo chmod a+rx /usr/local/bin/yt-dlp  # Make executable
+aria2c https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp --dir ~/.local/bin -o yt-dlp
+chmod a+rx ~/.local/bin/yt-dlp  # Make executable
 ```
 
 To update, run: 
 ```bash
-sudo yt-dlp -U
+yt-dlp -U
 ```
-
 
 # With [PIP](https://pypi.org/project/pip)
 

--- a/Installation.md
+++ b/Installation.md
@@ -33,6 +33,7 @@ To update, run:
 yt-dlp -U
 ```
 
+
 # With [PIP](https://pypi.org/project/pip)
 
 You can install the [PyPI package](https://pypi.org/project/yt-dlp) with:

--- a/Installation.md
+++ b/Installation.md
@@ -14,24 +14,42 @@ You can simply download the [correct binary file](https://github.com/yt-dlp/yt-d
 In UNIX-like OSes (MacOS, Linux, BSD), you can also install the same in one of the following ways:
 
 ```bash
-curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o ~/.local/bin/yt-dlp
-chmod a+rx ~/.local/bin/yt-dlp  # Make executable
+mkdir -p ~/bin
+curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o ~/bin/yt-dlp
+chmod a+rx ~/bin/yt-dlp  # Make executable
 ```
 
 ```bash
-wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O ~/.local/bin/yt-dlp
-chmod a+rx ~/.local/bin/yt-dlp  # Make executable
+mkdir -p ~/bin
+wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O ~/bin/yt-dlp
+chmod a+rx ~/bin/yt-dlp  # Make executable
 ```
 
 ```bash
-aria2c https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp --dir ~/.local/bin -o yt-dlp
-chmod a+rx ~/.local/bin/yt-dlp  # Make executable
+mkdir -p ~/bin
+aria2c https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp --dir ~/bin -o yt-dlp
+chmod a+rx ~/bin/yt-dlp  # Make executable
+```
+
+If `~/bin` is not already in your path, you can add it
+###### Linux,BSD
+Edit your the appropriate file for your shell(i.e. `~/.bashrc`, `~/.zshrc`, etc) and add the following:
+```bash
+PATH=$PATH:~/bin
+export PATH
+```
+
+###### MacOS
+Create a file `/etc/path.d/80_bin` with the following contents
+```text
+~/bin
 ```
 
 To update, run: 
 ```bash
 yt-dlp -U
 ```
+
 
 
 # With [PIP](https://pypi.org/project/pip)


### PR DESCRIPTION
Recommending running `sudo yt-dlp -U` is somewhat questionable advice from a security perspective.

To avoid this, we can modify the instructions to install to `~/.local/bin` instead where `sudo` is not needed.