### PR TITLE
Don't refer to pip in all-caps.

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -36,7 +36,7 @@ sudo yt-dlp -U
 ```
 
 
-# With [PIP](https://pypi.org/project/pip)
+# With [pip](https://pypi.org/project/pip)
 
 You can install the [PyPI package](https://pypi.org/project/yt-dlp) with:
 ```bash


### PR DESCRIPTION
The documentation (the README and wiki) refers to pip, the python package manager, as "PIP", in all caps. It took me a moment to work out that this meant the python package manager, because I don't think I've ever seen it referred to like that. Certainly, the [pip documentation](https://pip.pypa.io/en/stable/) doesn't do this; even going so far as to refer to it in all-lowercase when it's at the start of a sentence.

This just isn't the name of the thing you're trying to refer to, which, for me at least, was temporarily a source of significant confusion. This MR edits these references to refer to pip in the way that pip itself does.