### PR TITLE
Update Arch Linux package URL in Installation.md

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -87,7 +87,7 @@ To update, run:
 brew upgrade yt-dlp
 ```
 
-### [pacman](https://archlinux.org/packages/community/any/yt-dlp/)
+### [pacman](https://archlinux.org/packages/extra/any/yt-dlp/)
 
 Arch Linux users can install it from the official community repository:
 ```bash


### PR DESCRIPTION
The old URL returns 404 now.