### PR TITLE
[Installation] Quote args containing brackets

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -41,7 +41,7 @@ To use shell completion (autocomplete), look for the completion files in the [so
 
 You can install the [PyPI package](https://pypi.org/project/yt-dlp) with:
 ```bash
-python3 -m pip install -U yt-dlp[default]
+python3 -m pip install -U "yt-dlp[default]"
 ```
 
 You can install without any of the optional dependencies using:
@@ -52,7 +52,7 @@ python3 -m pip install --no-deps -U yt-dlp
 
 You can also install the nightly version of yt-dlp with:
 ```bash
-python3 -m pip install -U --pre yt-dlp[default]
+python3 -m pip install -U --pre "yt-dlp[default]"
 ```
 
 <a id="pip-master"></a>
@@ -67,7 +67,7 @@ On some systems, you may need to use `py` or `python` instead of `python3`
 
 To update, run:
 ```bash
-python3 -m pip install -U yt-dlp[default]
+python3 -m pip install -U "yt-dlp[default]"
 ```
 
 
@@ -198,11 +198,11 @@ You can use yt-dlp on Android using [Termux](https://termux.dev). Once Termux is
 termux-setup-storage                 # Allow termux to download files into your phone's storage
 pkg update && pkg upgrade            # Update all packages
 pkg install libexpat openssl python  # Install python
-pip install -U yt-dlp[default]       # Install yt-dlp with default dependencies
+pip install -U "yt-dlp[default]"     # Install yt-dlp with default dependencies
 pkg install ffmpeg                   # OPTIONAL: Install ffmpeg
 ```
 
 To update, run:
 ```bash
-pip install -U yt-dlp[default]
+pip install -U "yt-dlp[default]"
 ```


### PR DESCRIPTION
Some pip installation commands that we recommend don't work in zsh, since zsh attempts to expand any unquoted `[`.

zsh manual:
```
FILENAME GENERATION
       If  a  word  contains an unquoted instance of one of the characters ‘*',
       ‘(', ‘|', ‘<', ‘[', or ‘?', it is regarded as  a  pattern  for  filename
       generation,  unless  the GLOB option is unset.
```

Solution: quote the args