### PR TITLE
Update `Installation.md` to explicitly install `pip`

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -210,7 +210,7 @@ You can use yt-dlp on Android using [Termux](https://termux.dev). Once Termux is
 ```bash
 termux-setup-storage                 # Allow termux to download files into your phone's storage
 pkg update && pkg upgrade            # Update all packages
-pkg install libexpat openssl python  # Install python
+pkg install python python-pip        # Install Python, its package manager, and their dependencies
 pip install -U "yt-dlp[default]"     # Install yt-dlp with default dependencies
 pkg install ffmpeg                   # OPTIONAL: Install ffmpeg
 ```

--- a/Installation.md
+++ b/Installation.md
@@ -210,7 +210,7 @@ You can use yt-dlp on Android using [Termux](https://termux.dev). Once Termux is
 ```bash
 termux-setup-storage                 # Allow termux to download files into your phone's storage
 pkg update && pkg upgrade            # Update all packages
-pkg install python python-pip        # Install Python, its package manager, and their dependencies
+pkg install python python-pip        # Install Python and pip
 pip install -U "yt-dlp[default]"     # Install yt-dlp with default dependencies
 pkg install ffmpeg                   # OPTIONAL: Install ffmpeg
 ```


### PR DESCRIPTION
Also:
- `rm libexpat openssl`, because they are required deps, so they will always be installed. No need to `mark-manual` because `yt-dlp` doesn't use those deps directly
- Improve side comment

[Context](https://github.com/yt-dlp/yt-dlp/issues/10820#issuecomment-2699857095)