### PR TITLE
Add —-source winget to winget commands to prevent winget installing yt-dlp from the Microsoft Store

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -196,12 +196,12 @@ choco upgrade yt-dlp
 ### [winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/)
 
 ```powershell
-winget install yt-dlp
+winget install yt-dlp --source winget
 ```
 
 To update, run:
 ```powershell
-winget upgrade yt-dlp
+winget upgrade yt-dlp --source winget
 ```
 
 ## Android


### PR DESCRIPTION
By default winget will search both the Microsoft Store and the Winget manifests. Whilst the winget manifest repo is moderated (importantly, manifests presumably have to use the official binaries), I highly doubt that the Microsoft Store has the same level of moderation (for a start, it uses binaries instead of manifests). Whilst I’m not aware of any packages named yt-dlp in the Microsoft Store, it’s best to avoid that risk all together