### PR TITLE
[Plugins] Add yt-nsig-dukpy

### DIFF
--- a/Plugins.md
+++ b/Plugins.md
@@ -10,6 +10,8 @@
     - Uses [Deno](https://deno.land) for decrypting YouTube nsig
 - [YouTube PO Token Framework](https://github.com/coletdjnz/yt-dlp-get-pot) by [coletdjnz](https://github.com/coletdjnz)
     - A plugin framework for yt-dlp to support fetching [PO Tokens](https://github.com/yt-dlp/yt-dlp/wiki/Extractors#po-token-guide) from external providers 
+- [YouTube nsig DukPy](https://github.com/alive4ever/yt-dlp-YTNSigDukpy) by [alive4ever](https://github.com/alive4ever)
+    - Uses [dukpy](https://github.com/amol-/dukpy) to decrypt YouTube nsig faster.
 
 ### Postprocessor
 


### PR DESCRIPTION
I am currently developing [simple watch page for some video on demand platform](/alive4ever/quarttube).

During testing of my web app, I got the feeling that the loading of YT watch page is slow, especially on low end systems.

This pull request adds `yt-nsig-dukpy` plugin to decrypt YT nsig, which took inspiration from yt-nsig-deno.

The difference is that the built-in jsinterp is not used at all to decrypt YT nsig when this plugin is installed to aim for fast nsig decryption.