### PR TITLE
Updated winget command in Installation.md

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -196,7 +196,7 @@ choco upgrade yt-dlp
 ### [winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/)
 
 ```powershell
-winget install yt-dlp
+winget install -e --id yt-dlp.yt-dlp
 ```
 
 To update, run:


### PR DESCRIPTION
Updated winget installation command as the current one finds additional package that matches the name criteria.
This way the installation uses package id and has no conflicts.