### PR TITLE
Update Home.md with project details and history

### DIFF
--- a/Home.md
+++ b/Home.md
@@ -1,7 +1,72 @@
-# Welcome to the yt-dlp wiki!
+# yt-dlp
 
-### Contributing to the wiki
+| | |
+|---|---|
+| **Status** | Maintained |
+| **First release** | 2021-01-07 |
+| **Language** | [Python](https://python.org) |
+| **Developers** | [yt-dlp maintainers](https://github.com/orgs/yt-dlp/people) |
+| **Website** | [github.com/yt-dlp/yt-dlp](https://github.com/yt-dlp/yt-dlp) |
 
-If you have any suggestions, open a PR against **https://github.com/yt-dlp/yt-dlp-wiki**
+**yt-dlp** is a [command-line](https://en.wikipedia.org/wiki/Command-line_interface) audio/video downloader that supports [thousands of sites](https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md) including [YouTube](https://youtube.com). It is a fork of [youtube-dl](https://github.com/ytdl-org/youtube-dl)[^1], originally forked via [youtube-dlc](https://github.com/yt-dlc/youtube-dlc). It uses [calendar versioning](https://calver.org/), so a release tag like `2026.03.17` is literally the date of that release. It is released under [The Unlicense](https://unlicense.org/), a public-domain dedication.
 
-Do not open issues about the wiki on the main repo
+[^1]: yt-dlp contributors. "yt-dlp github page". github.com/yt-dlp/yt-dlp. Retrieved 2026-05-24.
+
+---
+
+## History
+
+### youtube-dl
+
+[youtube-dl](https://github.com/ytdl-org/youtube-dl) was written by Ricardo García in August 2006 and became the de facto standard tool for video archival, eventually supporting over 1,000 websites. Maintainership changed hands several times — from García to Philipp Hagemeister, then to dstftw, and finally to dirkf in 2021. By 2020 the project had slowed significantly, with pull requests accumulating unmerged for months and YouTube compatibility fixes arriving weeks late.
+
+In October 2020, the RIAA issued a DMCA takedown notice to GitHub, arguing that youtube-dl circumvented YouTube's rolling cipher (a form of DRM) under Section 1201 of US copyright law. GitHub initially complied and removed the repository. After intervention from the [EFF](https://www.eff.org/) and significant community backlash, GitHub restored the project in November 2020 and announced a $1 million legal defense fund for future similar situations. Despite reinstatement, development on youtube-dl did not recover meaningfully.
+
+### youtube-dlc
+
+In mid-2020, while youtube-dl was still alive but slow, a GitHub user named `blackjack4494` forked it as [youtube-dlc](https://github.com/yt-dlc/youtube-dlc) (the "c" standing for "community"). The backlog of unmerged PRs was cleared within days. However, youtube-dlc itself went semi-inactive by late 2020, as projects led by a single maintainer are fragile by nature.
+
+### yt-dlp
+
+yt-dlp was created on October 26, 2020 — three days into the RIAA takedown of youtube-dl — as a re-fork of youtube-dlc. Its name reflects its original lead maintainer, `pukkandan`. By January 2021, it had absorbed youtube-dlc's contributor base and become the dominant fork of youtube-dl, focused on features, rapid fixes, and a multi-maintainer governance model designed to avoid the single-point-of-failure problems of its predecessors.
+
+yt-dlp was included in Ubuntu starting with the 22.04 release. Debian 12.0 removed youtube-dl entirely, replacing it with an empty package that depends on yt-dlp.
+
+---
+
+## Maintainers
+
+yt-dlp is governed by the [yt-dlp GitHub organization](https://github.com/orgs/yt-dlp/people) under a collective maintainer model rather than a single lead. Current and past core maintainers include:
+
+| Handle | Role |
+|---|---|
+| `pukkandan` | Original creator and owner; drove the early feature surge |
+| `bashonly` | Core maintainer; major contributor to YouTube extractor fixes and infrastructure |
+| `coletdjnz` | Core maintainer; deep YouTube Innertube client work |
+| `Grub4K` | Core maintainer |
+| `seproDev` | Core maintainer; active across many extractors |
+| `shirt-dev` | Maintainer |
+| `Ashish0804` | Maintainer |
+| `dirkf` | Contributor; also current maintainer of upstream youtube-dl |
+
+The official contact for the maintainer team is [maintainers@yt-dlp.org](mailto:maintainers@yt-dlp.org).
+
+---
+
+## Differences from youtube-dl
+
+yt-dlp diverges from youtube-dl in several significant ways.
+
+### Speed of fixes
+
+yt-dlp ships extractor fixes within hours of a YouTube breakage; youtube-dl can take weeks. This is the most practically important difference for day-to-day use.
+
+A full list of options can be found by running `yt-dlp --help` or in the [official README](https://github.com/yt-dlp/yt-dlp#usage-and-options).
+
+---
+
+## See also
+
+- [youtube-dl](https://github.com/ytdl-org/youtube-dl) — the original project yt-dlp is forked from
+- [FFmpeg](https://ffmpeg.org/) — used by yt-dlp for post-processing
+- [SponsorBlock](https://sponsor.ajay.app/) — community-driven sponsor segment database integrated into yt-dlp


### PR DESCRIPTION
This pull request significantly expands and restructures the `Home.md` file to provide a comprehensive introduction and background for the `yt-dlp` project. The changes transform the file from a brief wiki contribution note into a detailed overview, including project history, governance, and key differences from upstream projects.

Key improvements include:

**Project Overview and Documentation:**
* Adds a project summary table and a clear description of what `yt-dlp` is, its release model, and license.
* Introduces a "See also" section linking to related projects and tools.

**Historical Context:**
* Provides a detailed history of `youtube-dl`, the DMCA takedown, the `youtube-dlc` fork, and the creation and evolution of `yt-dlp`, including its adoption in major Linux distributions.

**Governance and Maintainers:**
* Documents the project's governance model, lists current and past core maintainers, and provides an official contact email.

**Comparison with Upstream:**
* Highlights the main differences between `yt-dlp` and `youtube-dl`, especially regarding the speed of fixes and ongoing maintenance.

These changes greatly improve the clarity, usefulness, and professionalism of the project’s main wiki page.